### PR TITLE
linearization is set to default if we try to create entity that already exists

### DIFF
--- a/src/main/java/edu/stanford/protege/webprotege/linearizationservice/handlers/CreateLinearizationFromParentCommandHandler.java
+++ b/src/main/java/edu/stanford/protege/webprotege/linearizationservice/handlers/CreateLinearizationFromParentCommandHandler.java
@@ -37,6 +37,11 @@ public class CreateLinearizationFromParentCommandHandler implements CommandHandl
 
     @Override
     public Mono<CreateLinearizationFromParentResponse> handleRequest(CreateLinearizationFromParentRequest request, ExecutionContext executionContext) {
+        var currentEntityHistory = linearizationHistoryService.getExistingHistoryOrderedByRevision(request.newEntityIri(), request.projectId());
+        if(currentEntityHistory.isPresent()){
+            return Mono.just(CreateLinearizationFromParentResponse.create());
+        }
+
         var parentEntityHistory = linearizationHistoryService.getExistingHistoryOrderedByRevision(request.parentEntityIri(), request.projectId());
         if (parentEntityHistory.isEmpty()) {
             throw new RuntimeException("Parent entity history is empty!");

--- a/src/main/java/edu/stanford/protege/webprotege/linearizationservice/mappers/LinearizationEventMapper.java
+++ b/src/main/java/edu/stanford/protege/webprotege/linearizationservice/mappers/LinearizationEventMapper.java
@@ -203,25 +203,16 @@ public class LinearizationEventMapper {
 
     private void addUnspecifiedTitleResidual(Set<LinearizationEvent> events, WhoficEntityLinearizationSpecification specification, LinearizationResiduals oldResiduals) {
         if (specification.linearizationResiduals() != null) {
-            String newUnspecifiedTitle = specification.linearizationResiduals().getUnspecifiedResidualTitle();
+            String newTitle = specification.linearizationResiduals().getUnspecifiedResidualTitle();
+            String oldTitle = oldResiduals != null ? oldResiduals.getUnspecifiedResidualTitle() : null;
 
-            boolean shouldSaveEmptyString = oldResiduals != null &&
-                    oldResiduals.getUnspecifiedResidualTitle() != null &&
-                    newUnspecifiedTitle != null &&
-                    newUnspecifiedTitle.isEmpty() &&
-                    !oldResiduals.getUnspecifiedResidualTitle().equals(newUnspecifiedTitle);
-
-            if (shouldSaveEmptyString ||
-                    (newUnspecifiedTitle != null && !newUnspecifiedTitle.isEmpty() &&
-                            (oldResiduals == null ||
-                                    oldResiduals.getUnspecifiedResidualTitle() == null ||
-                                    !oldResiduals.getUnspecifiedResidualTitle().equals(newUnspecifiedTitle))
-                    )
-            ) {
-                events.add(new SetUnspecifiedResidualTitle(newUnspecifiedTitle));
+            if (shouldAddNewTitle(newTitle, oldTitle) ||
+                    shouldSaveEmptyString(newTitle, oldTitle)) {
+                events.add(new SetUnspecifiedResidualTitle(newTitle));
             }
         }
     }
+
 
     private void addOtherSpecifiedTitleResidual(Set<LinearizationEvent> events, WhoficEntityLinearizationSpecification specification) {
         if (specification.linearizationResiduals() != null && specification.linearizationResiduals().getOtherSpecifiedResidualTitle() != null) {
@@ -232,20 +223,26 @@ public class LinearizationEventMapper {
     private void addOtherSpecifiedTitleResidual(Set<LinearizationEvent> events, WhoficEntityLinearizationSpecification specification, LinearizationResiduals oldResiduals) {
         if (specification.linearizationResiduals() != null) {
             String newTitle = specification.linearizationResiduals().getOtherSpecifiedResidualTitle();
+            String oldTitle = oldResiduals != null ? oldResiduals.getOtherSpecifiedResidualTitle() : null;
 
-            boolean shouldSaveEmptyString = oldResiduals != null && oldResiduals.getOtherSpecifiedResidualTitle() != null && newTitle.isEmpty();
-
-            if (shouldSaveEmptyString ||
-                    (newTitle != null &&
-                            !newTitle.isEmpty() &&
-                            (oldResiduals == null ||
-                                    oldResiduals.getOtherSpecifiedResidualTitle() == null ||
-                                    !oldResiduals.getOtherSpecifiedResidualTitle().equals(newTitle))
-                    )
-            ) {
+            if (shouldSaveEmptyString(newTitle, oldTitle) ||
+                    shouldAddNewTitle(newTitle, oldTitle)) {
                 events.add(new SetOtherSpecifiedResidualTitle(newTitle));
             }
         }
+    }
+
+    private boolean shouldAddNewTitle(String newTitle, String oldTitle) {
+        return newTitle != null &&
+                !newTitle.isEmpty() &&
+                (oldTitle == null || !oldTitle.equals(newTitle));
+    }
+
+    private boolean shouldSaveEmptyString(String newTitle, String oldTitle) {
+        return oldTitle != null &&
+                newTitle != null &&
+                newTitle.isEmpty() &&
+                !oldTitle.equals(newTitle);
     }
 
 

--- a/src/test/java/edu/stanford/protege/webprotege/linearizationservice/mappers/LinearizationEventMapperTest.java
+++ b/src/test/java/edu/stanford/protege/webprotege/linearizationservice/mappers/LinearizationEventMapperTest.java
@@ -10,7 +10,7 @@ import org.semanticweb.owlapi.model.IRI;
 import java.util.*;
 
 import static edu.stanford.protege.webprotege.linearizationservice.testUtils.RandomHelper.*;
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.*;
 
 @ExtendWith(MockitoExtension.class)
 public class LinearizationEventMapperTest {
@@ -94,4 +94,265 @@ public class LinearizationEventMapperTest {
             }
         });
     }
+
+    @Test
+    public void GIVEN_nonEmptyOldTitleAndDifferentNewTitle_WHEN_mapLinearizationResidualsToEvents_called_THEN_eventAdded() {
+        String oldTitle = "Old Title";
+        String newTitle = "New Title";
+
+        WhoficEntityLinearizationSpecification oldSpec = new WhoficEntityLinearizationSpecification(
+                IRI.create(getRandomIri()),
+                new LinearizationResiduals(
+                        ThreeStateBoolean.FALSE,
+                        ThreeStateBoolean.FALSE,
+                        oldTitle,
+                        null
+                ),
+                List.of()
+        );
+
+        WhoficEntityLinearizationSpecification newSpec = new WhoficEntityLinearizationSpecification(
+                IRI.create(getRandomIri()),
+                new LinearizationResiduals(
+                        ThreeStateBoolean.FALSE,
+                        ThreeStateBoolean.FALSE,
+                        newTitle,
+                        null
+                ),
+                List.of()
+        );
+
+        Set<LinearizationEvent> events = eventMapper.mapLinearizationResidualsToEvents(newSpec, oldSpec);
+
+        assertEquals(1, events.size());
+        assertTrue(events.stream().anyMatch(event -> event instanceof SetOtherSpecifiedResidualTitle));
+        assertEquals(newTitle, events.iterator().next().getValue());
+    }
+
+    @Test
+    public void GIVEN_emptyOldTitleAndEmptyNewTitle_WHEN_mapLinearizationResidualsToEvents_called_THEN_noEventAdded() {
+        WhoficEntityLinearizationSpecification oldSpec = new WhoficEntityLinearizationSpecification(
+                IRI.create(getRandomIri()),
+                new LinearizationResiduals(
+                        ThreeStateBoolean.FALSE,
+                        ThreeStateBoolean.FALSE,
+                        "",
+                        null
+                ),
+                List.of()
+        );
+
+        WhoficEntityLinearizationSpecification newSpec = new WhoficEntityLinearizationSpecification(
+                IRI.create(getRandomIri()),
+                new LinearizationResiduals(
+                        ThreeStateBoolean.FALSE,
+                        ThreeStateBoolean.FALSE,
+                        "",
+                        null
+                ),
+                List.of()
+        );
+
+        Set<LinearizationEvent> events = eventMapper.mapLinearizationResidualsToEvents(newSpec, oldSpec);
+
+        assertTrue(events.isEmpty());
+    }
+
+    @Test
+    public void GIVEN_nullOldTitleAndNonEmptyNewTitle_WHEN_mapLinearizationResidualsToEvents_called_THEN_eventAdded() {
+        String newTitle = "New Title";
+
+        WhoficEntityLinearizationSpecification oldSpec = new WhoficEntityLinearizationSpecification(
+                IRI.create(getRandomIri()),
+                new LinearizationResiduals(
+                        ThreeStateBoolean.FALSE,
+                        ThreeStateBoolean.FALSE,
+                        null,
+                        null
+                ),
+                List.of()
+        );
+
+        WhoficEntityLinearizationSpecification newSpec = new WhoficEntityLinearizationSpecification(
+                IRI.create(getRandomIri()),
+                new LinearizationResiduals(
+                        ThreeStateBoolean.FALSE,
+                        ThreeStateBoolean.FALSE,
+                        newTitle,
+                        null
+                ),
+                List.of()
+        );
+
+        Set<LinearizationEvent> events = eventMapper.mapLinearizationResidualsToEvents(newSpec, oldSpec);
+
+        assertEquals(1, events.size());
+        assertTrue(events.stream().anyMatch(event -> event instanceof SetOtherSpecifiedResidualTitle));
+        assertEquals(newTitle, events.iterator().next().getValue());
+    }
+
+    @Test
+    public void GIVEN_nonEmptyOldTitleAndEmptyNewTitle_WHEN_mapLinearizationResidualsToEvents_called_THEN_eventAdded() {
+        String oldTitle = "Old Title";
+
+        WhoficEntityLinearizationSpecification oldSpec = new WhoficEntityLinearizationSpecification(
+                IRI.create(getRandomIri()),
+                new LinearizationResiduals(
+                        ThreeStateBoolean.FALSE,
+                        ThreeStateBoolean.FALSE,
+                        oldTitle,
+                        null
+                ),
+                List.of()
+        );
+
+        WhoficEntityLinearizationSpecification newSpec = new WhoficEntityLinearizationSpecification(
+                IRI.create(getRandomIri()),
+                new LinearizationResiduals(
+                        ThreeStateBoolean.FALSE,
+                        ThreeStateBoolean.FALSE,
+                        "",
+                        null
+                ),
+                List.of()
+        );
+
+        Set<LinearizationEvent> events = eventMapper.mapLinearizationResidualsToEvents(newSpec, oldSpec);
+
+        assertEquals(1, events.size());
+        assertTrue(events.stream().anyMatch(event -> event instanceof SetOtherSpecifiedResidualTitle));
+        assertEquals("", events.iterator().next().getValue());
+    }
+
+    //----------------------------------------------------------------------------
+
+    @Test
+    public void GIVEN_nonEmptyOldUnspecifiedTitleAndDifferentNewTitle_WHEN_mapLinearizationResidualsToEvents_called_THEN_eventAdded() {
+        String oldTitle = "Old Title";
+        String newTitle = "New Title";
+
+        WhoficEntityLinearizationSpecification oldSpec = new WhoficEntityLinearizationSpecification(
+                IRI.create(getRandomIri()),
+                new LinearizationResiduals(
+                        ThreeStateBoolean.FALSE,
+                        ThreeStateBoolean.FALSE,
+                        null,
+                        oldTitle
+                ),
+                List.of()
+        );
+
+        WhoficEntityLinearizationSpecification newSpec = new WhoficEntityLinearizationSpecification(
+                IRI.create(getRandomIri()),
+                new LinearizationResiduals(
+                        ThreeStateBoolean.FALSE,
+                        ThreeStateBoolean.FALSE,
+                        null,
+                        newTitle
+                ),
+                List.of()
+        );
+
+        Set<LinearizationEvent> events = eventMapper.mapLinearizationResidualsToEvents(newSpec, oldSpec);
+
+        assertEquals(1, events.size());
+        assertTrue(events.stream().anyMatch(event -> event instanceof SetUnspecifiedResidualTitle));
+        assertEquals(newTitle, events.iterator().next().getValue());
+    }
+
+    @Test
+    public void GIVEN_emptyOldUnspecifiedTitleAndEmptyNewTitle_WHEN_mapLinearizationResidualsToEvents_called_THEN_noEventAdded() {
+        WhoficEntityLinearizationSpecification oldSpec = new WhoficEntityLinearizationSpecification(
+                IRI.create(getRandomIri()),
+                new LinearizationResiduals(
+                        ThreeStateBoolean.FALSE,
+                        ThreeStateBoolean.FALSE,
+                        null,
+                        ""
+                ),
+                List.of()
+        );
+
+        WhoficEntityLinearizationSpecification newSpec = new WhoficEntityLinearizationSpecification(
+                IRI.create(getRandomIri()),
+                new LinearizationResiduals(
+                        ThreeStateBoolean.FALSE,
+                        ThreeStateBoolean.FALSE,
+                        null,
+                        ""
+                ),
+                List.of()
+        );
+
+        Set<LinearizationEvent> events = eventMapper.mapLinearizationResidualsToEvents(newSpec, oldSpec);
+
+        assertTrue(events.isEmpty());
+    }
+
+    @Test
+    public void GIVEN_nullOldUnspecifiedTitleAndNonEmptyNewTitle_WHEN_mapLinearizationResidualsToEvents_called_THEN_eventAdded() {
+        String newTitle = "New Title";
+
+        WhoficEntityLinearizationSpecification oldSpec = new WhoficEntityLinearizationSpecification(
+                IRI.create(getRandomIri()),
+                new LinearizationResiduals(
+                        ThreeStateBoolean.FALSE,
+                        ThreeStateBoolean.FALSE,
+                        null,
+                        null
+                ),
+                List.of()
+        );
+
+        WhoficEntityLinearizationSpecification newSpec = new WhoficEntityLinearizationSpecification(
+                IRI.create(getRandomIri()),
+                new LinearizationResiduals(
+                        ThreeStateBoolean.FALSE,
+                        ThreeStateBoolean.FALSE,
+                        null,
+                        newTitle
+                ),
+                List.of()
+        );
+
+        Set<LinearizationEvent> events = eventMapper.mapLinearizationResidualsToEvents(newSpec, oldSpec);
+
+        assertEquals(1, events.size());
+        assertTrue(events.stream().anyMatch(event -> event instanceof SetUnspecifiedResidualTitle));
+        assertEquals(newTitle, events.iterator().next().getValue());
+    }
+
+    @Test
+    public void GIVEN_nonEmptyOldUnspecifiedTitleAndEmptyNewTitle_WHEN_mapLinearizationResidualsToEvents_called_THEN_eventAdded() {
+        String oldTitle = "Old Title";
+
+        WhoficEntityLinearizationSpecification oldSpec = new WhoficEntityLinearizationSpecification(
+                IRI.create(getRandomIri()),
+                new LinearizationResiduals(
+                        ThreeStateBoolean.FALSE,
+                        ThreeStateBoolean.FALSE,
+                        null,
+                        oldTitle
+                ),
+                List.of()
+        );
+
+        WhoficEntityLinearizationSpecification newSpec = new WhoficEntityLinearizationSpecification(
+                IRI.create(getRandomIri()),
+                new LinearizationResiduals(
+                        ThreeStateBoolean.FALSE,
+                        ThreeStateBoolean.FALSE,
+                        null,
+                        ""
+                ),
+                List.of()
+        );
+
+        Set<LinearizationEvent> events = eventMapper.mapLinearizationResidualsToEvents(newSpec, oldSpec);
+
+        assertEquals(1, events.size());
+        assertTrue(events.stream().anyMatch(event -> event instanceof SetUnspecifiedResidualTitle));
+        assertEquals("", events.iterator().next().getValue());
+    }
+
 }


### PR DESCRIPTION
added fix to not create default linearization revision if linearization already exists. Fixed some null pointer exceptions for residuals in LinearizationEventMapper and added some more tests.