### PR TITLE
add new import logic for telescopic linearizations

### DIFF
--- a/src/test/java/edu/stanford/protege/webprotege/linearizationservice/handlers/CreateLinearizationFromParentCommandHandlerTest.java
+++ b/src/test/java/edu/stanford/protege/webprotege/linearizationservice/handlers/CreateLinearizationFromParentCommandHandlerTest.java
@@ -121,7 +121,8 @@ class CreateLinearizationFromParentCommandHandlerTest {
              if (event instanceof SetCodingNote) {
                 assertEquals("", event.getValue());
             } else if (event instanceof SetIncludedInLinearization) {
-                assertEquals(LinearizationStateCell.UNKNOWN.name(), event.getValue());
+                assertTrue(event.getValue().equals(LinearizationStateCell.UNKNOWN.name()) ||
+                          event.getValue().equals(LinearizationStateCell.FOLLOW_BASE_LINEARIZATION.name()));
             } else if (event instanceof SetLinearizationParent) {
                 assertEquals("", event.getValue());
             } else if (event instanceof SetSuppressedOtherSpecifiedResidual) {


### PR DESCRIPTION
isGrouping and isPartOf from now on , will have this logic : 

isNotDerived ?

- it has value ? -> set value
- is empty ? -> set unkown

isDerived

- is has the same value as parent or is unknown?  -> follow parent value
- it has a different value (True or False) -> set value
- is empty ? -> follow parent value
